### PR TITLE
chore(ci): 更新镜像仓库配置

### DIFF
--- a/.github/workflows/build-and-push-collector.yaml
+++ b/.github/workflows/build-and-push-collector.yaml
@@ -17,8 +17,8 @@ jobs:
   build-and-push-collector:
     runs-on: ubuntu-latest
     env:
-      IMAGE_REGISTRY_SERVICE: ${{ vars.IMAGE_REGISTRY || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
-      IMAGE_REPOSITORY: ${{ vars.COLLECTOR_IMAGE_REPOSITORY || 'log-collector' }}
+      IMAGE_REGISTRY_SERVICE: ${{ vars.IMAGE_REGISTRY || 'opensource-registry.cn-hangzhou.cr.aliyuncs.com' }}
+      IMAGE_REPOSITORY: ${{ vars.COLLECTOR_IMAGE_REPOSITORY || 'higress-group' }}
       COLLECTOR_NAME: log-collector
     steps:
       - name: Set version

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -15,7 +15,7 @@ jobs:
   build-and-push-wasm-plugin-image:
     runs-on: ubuntu-latest
     env:
-      IMAGE_REGISTRY_SERVICE: ${{ vars.IMAGE_REGISTRY || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
+      IMAGE_REGISTRY_SERVICE: ${{ vars.IMAGE_REGISTRY || 'opensource-registry.cn-hangzhou.cr.aliyuncs.com' }}
       IMAGE_REPOSITORY: ${{ vars.PLUGIN_IMAGE_REPOSITORY || 'plugins' }}
       PLUGIN_NAME: db-log-pusher
       GO_VERSION: 1.24.0


### PR DESCRIPTION
- 将 IMAGE_REGISTRY_SERVICE 从 higress-registry.cn-hangzhou.cr.aliyuncs.com 更改为 opensource-registry.cn-hangzhou.cr.aliyuncs.com
- 将 COLLECTOR_IMAGE_REPOSITORY 默认值从 log-collector 更改为 higress-group
- 更新 build-and-push-wasm-plugin-image 工作流中的镜像仓库地址