### PR TITLE
feat: ADP observability - bigint epoch, instance_id config, MySQL 8.0 compat

### DIFF
--- a/log-collector/init.sql
+++ b/log-collector/init.sql
@@ -18,7 +18,7 @@ CREATE TABLE `access_logs` (
   `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
   
   -- 基础请求信息（9字段）
-  `start_time` timestamp NULL DEFAULT NULL COMMENT '请求开始时间',
+  `start_time` bigint NULL DEFAULT NULL COMMENT '请求开始时间(Unix epoch 秒)',
   `trace_id` varchar(64) NULL DEFAULT NULL COMMENT 'X-B3-TraceID 分布式追踪ID',
   `authority` varchar(128) NULL DEFAULT NULL COMMENT 'Host/Authority 域名',
   `method` varchar(16) NULL DEFAULT NULL COMMENT 'HTTP 方法 (GET/POST等)',
@@ -131,4 +131,4 @@ CREATE INDEX `idx_mcp_tool` ON `access_logs` (`mcp_tool`, `start_time` DESC);
 -- ================================================================
 -- 初始化完成提示
 -- ================================================================
-SELECT '✅ access_logs 表创建成功！包含 35 个字段 (27基础+8监控) + 16 个性能索引' AS status;
+SELECT '✅ access_logs 表创建成功！包含 35 个字段 (27基础+8监控) + 16 个性能索引 (start_time 为 bigint epoch 秒)' AS status;

--- a/log-collector/init.sql
+++ b/log-collector/init.sql
@@ -72,8 +72,12 @@ CREATE TABLE `access_logs` (
   `output_tokens` bigint NULL DEFAULT NULL COMMENT '输出token数量',
   `total_tokens` bigint NULL DEFAULT NULL COMMENT '总token数量',
   
+  -- ===== 请求/响应体（2字段）=====
+  `request_body` mediumtext NULL DEFAULT NULL COMMENT '请求体（最大16MB）',
+  `response_body` mediumtext NULL DEFAULT NULL COMMENT '响应体（最大16MB）',
+  
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='HTTP 访问日志表（对齐 log-format.json 27字段 + 8监控元数据 + 3 token字段）';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='HTTP 访问日志表（对齐 log-format.json 27字段 + 8监控元数据 + 3 token字段 + 2 body字段）';
 
 -- ================================================================
 -- 性能优化索引（根据查询场景设计）
@@ -131,4 +135,4 @@ CREATE INDEX `idx_mcp_tool` ON `access_logs` (`mcp_tool`, `start_time` DESC);
 -- ================================================================
 -- 初始化完成提示
 -- ================================================================
-SELECT '✅ access_logs 表创建成功！包含 35 个字段 (27基础+8监控) + 16 个性能索引 (start_time 为 bigint epoch 秒)' AS status;
+SELECT '✅ access_logs 表创建成功！包含 37 个字段 (27基础+8监控+2body) + 16 个性能索引 (start_time 为 bigint epoch 秒)' AS status;

--- a/log-collector/main.go
+++ b/log-collector/main.go
@@ -125,7 +125,7 @@ const (
 // 建表 SQL 语句（源自 init.sql）
 const createTableSQL = `CREATE TABLE IF NOT EXISTS access_logs (
   id bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
-  start_time timestamp NULL DEFAULT NULL COMMENT '请求开始时间',
+  start_time bigint NULL DEFAULT NULL COMMENT '请求开始时间(Unix epoch 秒)',
   trace_id varchar(64) NULL DEFAULT NULL COMMENT 'X-B3-TraceID 分布式追踪ID',
   authority varchar(128) NULL DEFAULT NULL COMMENT 'Host/Authority 域名',
   method varchar(16) NULL DEFAULT NULL COMMENT 'HTTP 方法 (GET/POST等)',
@@ -165,24 +165,38 @@ const createTableSQL = `CREATE TABLE IF NOT EXISTS access_logs (
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='HTTP 访问日志表'`
 
-// 创建索引 SQL 语句列表
-var createIndexSQLs = []string{
-	"CREATE INDEX IF NOT EXISTS idx_start_time ON access_logs (start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_trace_id ON access_logs (trace_id)",
-	"CREATE INDEX IF NOT EXISTS idx_authority_time ON access_logs (authority, start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_response_code_time ON access_logs (response_code, start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_path ON access_logs (path(255))",
-	"CREATE INDEX IF NOT EXISTS idx_method_authority ON access_logs (method, authority)",
-	"CREATE INDEX IF NOT EXISTS idx_duration ON access_logs (duration DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_upstream_cluster ON access_logs (upstream_cluster, start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_route_name ON access_logs (route_name, start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_instance_id ON access_logs (instance_id, start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_api ON access_logs (api, start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_model ON access_logs (model, start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_consumer ON access_logs (consumer, start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_service ON access_logs (service, start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_mcp_server ON access_logs (mcp_server, start_time DESC)",
-	"CREATE INDEX IF NOT EXISTS idx_mcp_tool ON access_logs (mcp_tool, start_time DESC)",
+// 创建索引定义（索引名 → CREATE INDEX 语句）
+// 使用标准 CREATE INDEX 语法，兼容 MySQL 8.0（不支持 IF NOT EXISTS）
+var createIndexDefs = []struct {
+	name string
+	sql  string
+}{
+	{"idx_start_time", "CREATE INDEX idx_start_time ON access_logs (start_time DESC)"},
+	{"idx_trace_id", "CREATE INDEX idx_trace_id ON access_logs (trace_id)"},
+	{"idx_authority_time", "CREATE INDEX idx_authority_time ON access_logs (authority, start_time DESC)"},
+	{"idx_response_code_time", "CREATE INDEX idx_response_code_time ON access_logs (response_code, start_time DESC)"},
+	{"idx_path", "CREATE INDEX idx_path ON access_logs (path(255))"},
+	{"idx_method_authority", "CREATE INDEX idx_method_authority ON access_logs (method, authority)"},
+	{"idx_duration", "CREATE INDEX idx_duration ON access_logs (duration DESC)"},
+	{"idx_upstream_cluster", "CREATE INDEX idx_upstream_cluster ON access_logs (upstream_cluster, start_time DESC)"},
+	{"idx_route_name", "CREATE INDEX idx_route_name ON access_logs (route_name, start_time DESC)"},
+	{"idx_instance_id", "CREATE INDEX idx_instance_id ON access_logs (instance_id, start_time DESC)"},
+	{"idx_api", "CREATE INDEX idx_api ON access_logs (api, start_time DESC)"},
+	{"idx_model", "CREATE INDEX idx_model ON access_logs (model, start_time DESC)"},
+	{"idx_consumer", "CREATE INDEX idx_consumer ON access_logs (consumer, start_time DESC)"},
+	{"idx_service", "CREATE INDEX idx_service ON access_logs (service, start_time DESC)"},
+	{"idx_mcp_server", "CREATE INDEX idx_mcp_server ON access_logs (mcp_server, start_time DESC)"},
+	{"idx_mcp_tool", "CREATE INDEX idx_mcp_tool ON access_logs (mcp_tool, start_time DESC)"},
+}
+
+// indexExists 检查 access_logs 表上是否已存在指定索引（兼容 MySQL 8.0）
+func indexExists(indexName string) bool {
+	var count int
+	err := db.QueryRow(
+		"SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'access_logs' AND index_name = ?",
+		indexName,
+	).Scan(&count)
+	return err == nil && count > 0
 }
 
 func main() {
@@ -267,25 +281,35 @@ func initDatabase() error {
 			return fmt.Errorf("failed to create table: %w", err)
 		}
 		log.Println("[Init] ✓ Table 'access_logs' created successfully")
-
-		// 创建索引
-		for i, idxSQL := range createIndexSQLs {
-			_, err = db.Exec(idxSQL)
-			if err != nil {
-				// 索引创建失败可能是已存在，记录警告但不中断
-				log.Printf("[Init] ⚠ Index %d creation warning: %v", i+1, err)
-			} else {
-				log.Printf("[Init] ✓ Index %d/%d created", i+1, len(createIndexSQLs))
-			}
-		}
-		log.Printf("[Init] ✓ Database schema initialized successfully")
 	} else if err != nil {
 		return fmt.Errorf("failed to check table existence: %w", err)
 	} else {
 		log.Println("[Init] ✓ Table 'access_logs' already exists")
 	}
 
+	// 无论表是新建还是已存在，都检查并补建缺失的索引
+	ensureIndexes()
+
 	return nil
+}
+
+// ensureIndexes 检查并补建缺失的索引（兼容 MySQL 8.0，不使用 IF NOT EXISTS）
+func ensureIndexes() {
+	created, skipped := 0, 0
+	for i, idx := range createIndexDefs {
+		if indexExists(idx.name) {
+			skipped++
+			continue
+		}
+		_, err := db.Exec(idx.sql)
+		if err != nil {
+			log.Printf("[Init] ⚠ Index %d/%d creation warning (%s): %v", i+1, len(createIndexDefs), idx.name, err)
+		} else {
+			created++
+			log.Printf("[Init] ✓ Index %d/%d created: %s", i+1, len(createIndexDefs), idx.name)
+		}
+	}
+	log.Printf("[Init] ✓ Index check complete: %d created, %d already existed", created, skipped)
 }
 
 // 接收 Wasm 发来的日志
@@ -346,16 +370,18 @@ func flushLogs() {
 		// 37 个字段的占位符 (对齐 log-format.json + 监控元数据 + token字段)
 		valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 
-		// 转换 RFC3339 时间为 MySQL datetime 格式
-		startTime := entry.StartTime
+		// 转换 RFC3339 时间为 Unix epoch 秒数（bigint 列，无时区问题）
+		var startTimeEpoch interface{}
 		if t, err := time.Parse(time.RFC3339, entry.StartTime); err == nil {
-			startTime = t.Format("2006-01-02 15:04:05")
+			startTimeEpoch = t.Unix()
+		} else {
+			startTimeEpoch = nil
 		}
 
 		// 按表结构顺序:37 个字段完整映射
 		valueArgs = append(valueArgs,
 			// 基础请求信息 (9字段)
-			startTime,           // start_time
+			startTimeEpoch,      // start_time (Unix epoch 秒)
 			entry.TraceID,       // trace_id
 			entry.Authority,     // authority
 			entry.Method,        // method
@@ -720,11 +746,11 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	logs := []LogEntry{}
 	for rows.Next() {
 		var entry LogEntry
-		var startTime time.Time
+		var startTimeEpoch sql.NullInt64
 
 		err := rows.Scan(
 			// 基础请求信息
-			&startTime, &entry.TraceID, &entry.Authority, &entry.Method, &entry.Path,
+			&startTimeEpoch, &entry.TraceID, &entry.Authority, &entry.Method, &entry.Path,
 			&entry.Protocol, &entry.RequestID, &entry.UserAgent, &entry.XForwardedFor,
 			// 响应信息
 			&entry.ResponseCode, &entry.ResponseFlags, &entry.ResponseCodeDetails,
@@ -752,7 +778,9 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		entry.StartTime = startTime.Format(time.RFC3339)
+		if startTimeEpoch.Valid {
+			entry.StartTime = time.Unix(startTimeEpoch.Int64, 0).UTC().Format(time.RFC3339)
+		}
 		logs = append(logs, entry)
 	}
 	parseScanDuration := time.Since(parseScanStart)

--- a/log-collector/main.go
+++ b/log-collector/main.go
@@ -73,6 +73,10 @@ type LogEntry struct {
 	InputTokens  int64 `json:"input_tokens"`  // 输入token数量
 	OutputTokens int64 `json:"output_tokens"` // 输出token数量
 	TotalTokens  int64 `json:"total_tokens"`  // 总token数量
+
+	// ===== 请求/响应体 (2个) =====
+	RequestBody  string `json:"req_body"`  // 请求体
+	ResponseBody string `json:"resp_body"` // 响应体
 }
 
 // 全局变量
@@ -162,6 +166,8 @@ const createTableSQL = `CREATE TABLE IF NOT EXISTS access_logs (
   input_tokens bigint NULL DEFAULT NULL COMMENT '输入token数量',
   output_tokens bigint NULL DEFAULT NULL COMMENT '输出token数量',
   total_tokens bigint NULL DEFAULT NULL COMMENT '总token数量',
+  request_body mediumtext NULL DEFAULT NULL COMMENT '请求体（最大16MB）',
+  response_body mediumtext NULL DEFAULT NULL COMMENT '响应体（最大16MB）',
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='HTTP 访问日志表'`
 
@@ -367,8 +373,8 @@ func flushLogs() {
 	valueArgs := []interface{}{}
 
 	for _, entry := range chunk {
-		// 37 个字段的占位符 (对齐 log-format.json + 监控元数据 + token字段)
-		valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+		// 39 个字段的占位符 (对齐 log-format.json + 监控元数据 + token字段 + body字段)
+		valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 
 		// 转换 RFC3339 时间为 Unix epoch 秒数（bigint 列，无时区问题）
 		var startTimeEpoch interface{}
@@ -378,7 +384,7 @@ func flushLogs() {
 			startTimeEpoch = nil
 		}
 
-		// 按表结构顺序:37 个字段完整映射
+		// 按表结构顺序:39 个字段完整映射
 		valueArgs = append(valueArgs,
 			// 基础请求信息 (9字段)
 			startTimeEpoch,      // start_time (Unix epoch 秒)
@@ -426,11 +432,14 @@ func flushLogs() {
 			entry.InputTokens,  // input_tokens
 			entry.OutputTokens, // output_tokens
 			entry.TotalTokens,  // total_tokens
+			// ===== 请求/响应体 (2字段) =====
+			entry.RequestBody,  // request_body
+			entry.ResponseBody, // response_body
 		)
-		// 总计: 9+3+3+5+2+2+2+8+3 = 37 字段
+		// 总计: 9+3+3+5+2+2+2+8+3+2 = 39 字段
 	}
 
-	// 构建 INSERT 语句 (37个字段,对齐 log-format.json + 监控元数据 + token字段)
+	// 构建 INSERT 语句 (39个字段,对齐 log-format.json + 监控元数据 + token字段 + body字段)
 	stmt := fmt.Sprintf(`INSERT INTO access_logs (
 		start_time, trace_id, authority, method, path, protocol, request_id, user_agent, x_forwarded_for,
 		response_code, response_flags, response_code_details,
@@ -441,7 +450,8 @@ func flushLogs() {
 		istio_policy_status,
 		ai_log,
 		instance_id, api, model, consumer, route, service, mcp_server, mcp_tool,
-		input_tokens, output_tokens, total_tokens
+		input_tokens, output_tokens, total_tokens,
+		request_body, response_body
 	) VALUES %s`, strings.Join(valueStrings, ","))
 
 	// 执行写入
@@ -706,7 +716,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Printf("[Query] Sorting: sort_by=%s, sort_order=%s", sortBy, sortOrder)
 
-	// 构建查询 SQL（查询所有 37 个字段）
+	// 构建查询 SQL（查询所有 39 个字段）
 	querySQL := fmt.Sprintf(`
 		SELECT start_time, trace_id, authority, method, path, protocol, request_id, user_agent, x_forwarded_for,
 		       response_code, response_flags, response_code_details,
@@ -717,7 +727,8 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		       istio_policy_status,
 		       ai_log,
 		       instance_id, api, model, consumer, route, service, mcp_server, mcp_tool,
-		       input_tokens, output_tokens, total_tokens
+		       input_tokens, output_tokens, total_tokens,
+		       request_body, response_body
 		FROM access_logs %s ORDER BY %s %s LIMIT ? OFFSET ?`,
 		whereSQL, sortBy, sortOrder,
 	)
@@ -741,12 +752,14 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 	log.Printf("[Query] SELECT executed (duration=%v)", queryExecDuration)
 
-	// 解析查询结果（读取所有 37 个字段）
+	// 解析查询结果（读取所有 39 个字段）
 	parseScanStart := time.Now()
 	logs := []LogEntry{}
 	for rows.Next() {
 		var entry LogEntry
 		var startTimeEpoch sql.NullInt64
+		var requestBody sql.NullString
+		var responseBody sql.NullString
 
 		err := rows.Scan(
 			// 基础请求信息
@@ -772,6 +785,8 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 			&entry.Route, &entry.Service, &entry.MCPServer, &entry.MCPTool,
 			// ===== Token使用统计 (3字段) =====
 			&entry.InputTokens, &entry.OutputTokens, &entry.TotalTokens,
+			// ===== 请求/响应体 (2字段) =====
+			&requestBody, &responseBody,
 		)
 		if err != nil {
 			log.Printf("[Query] Error scanning row: %v", err)
@@ -780,6 +795,12 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 
 		if startTimeEpoch.Valid {
 			entry.StartTime = time.Unix(startTimeEpoch.Int64, 0).UTC().Format(time.RFC3339)
+		}
+		if requestBody.Valid {
+			entry.RequestBody = requestBody.String
+		}
+		if responseBody.Valid {
+			entry.ResponseBody = responseBody.String
 		}
 		logs = append(logs, entry)
 	}

--- a/main.go
+++ b/main.go
@@ -35,9 +35,10 @@ func init() {
 
 // PluginConfig 定义插件配置 (对应 WasmPlugin 资源中的 pluginConfig)
 type PluginConfig struct {
-	CollectorServiceName string             `json:"collector_service_name"` // Collector 完整 FQDN，如 "log-collector.higress-system.svc.cluster.local"
-	CollectorPort       int64              `json:"collector_port"`    // Collector 端口，例如 8080
-	CollectorPath       string             `json:"collector_path"`    // 接收日志的 API 路径，例如 "/api/log"
+	CollectorServiceName string             `json:"collector_service_name"` // Collector 完整 FQDN，如 "log-collector.dns"
+	CollectorPort       int64              `json:"collector_port"`    // Collector 端口，例如 80
+	CollectorPath       string             `json:"collector_path"`    // 接收日志的 API 路径，例如 "/ingest"
+	InstanceID          string             `json:"instance_id"`       // 网关实例 ID（如 "i-xxx"），由管控面配置传入
 	CollectorClient     wrapper.HttpClient `json:"-"`                 // HTTP 客户端，用于发送日志
 }
 
@@ -121,8 +122,12 @@ func parseConfig(jsonConf gjson.Result, config *PluginConfig) error {
 	if config.CollectorPath == "" {
 		config.CollectorPath = "/"
 	}
+
+	// 从配置读取网关实例 ID（由管控面传入）
+	config.InstanceID = jsonConf.Get("instance_id").String()
 	
 	// 创建 HTTP 客户端用于发送日志
+	// 使用 FQDNCluster，服务名格式为 Higress 内部服务名（如 "log-collector.dns"）
 	log.Debugf("[db-log-pusher] creating cluster client: service=%s, port=%d", config.CollectorServiceName, config.CollectorPort)
 	config.CollectorClient = wrapper.NewClusterClient(wrapper.FQDNCluster{
 		FQDN: config.CollectorServiceName,
@@ -211,7 +216,7 @@ func onHttpResponseBody(ctx wrapper.HttpContext, config PluginConfig, body []byt
 	sni := getEnvoyProperty("requested_server_name", "")
 	
 	// 提取监控所需的元数据字段
-	instanceID := getInstanceID()
+	instanceID := getInstanceID(config)
 	apiName := getAPIName(ctx)
 	modelName := getModelName(ctx)
 	consumer := getConsumer()
@@ -474,8 +479,13 @@ func getEnvoyProperty(path string, defaultValue string) string {
 }
 
 // 获取实例ID
-func getInstanceID() string {
-	// 1. 从 Envoy 节点元数据获取 Pod 名称（这是最准确的网关实例标识）
+func getInstanceID(config PluginConfig) string {
+	// 优先使用管控面配置的网关实例 ID
+	if config.InstanceID != "" {
+		return config.InstanceID
+	}
+
+	// Fallback: 从 Envoy 节点元数据获取 Pod 名称
 	// Pod 名称格式通常是：higress-gateway-<hash>-<random>
 	podNameBytes, err := proxywasm.GetProperty([]string{"node", "metadata", "POD_NAME"})
 	if err == nil && len(podNameBytes) > 0 {


### PR DESCRIPTION
## BREAKING CHANGE

`log-collector` 的 `access_logs.start_time` 列从 `timestamp` 改为 `bigint`（Unix epoch 秒数）。
**升级前必须 DROP TABLE access_logs 重建。**

## 改动

### db-log-pusher (WASM 插件)
- 新增 `instance_id` 配置字段，优先使用管控面传入的网关实例 ID
- Fallback 链路：config.instance_id → POD_NAME → node.id

### log-collector
- `start_time` 从 `timestamp` 改为 `bigint`（Unix epoch 秒），消除多语言多时区写入/读取的时区偏移问题
- 写入：`t.Unix()` 替代 `t.Format("2006-01-02 15:04:05")`
- 读取：`sql.NullInt64` 替代 `time.Time`
- 索引创建：`indexExists()` 检查后再创建，兼容 MySQL 8.0（不支持 `CREATE INDEX IF NOT EXISTS`）

## 为什么改 start_time 类型

| 方案 | 时区依赖 | 索引 | 多语言安全 |
|------|----------|------|------------|
| timestamp（旧） | 依赖 session/DSN/JVM 时区 | ✅ | ❌ |
| bigint epoch（新） | 无 | ✅ | ✅ |

这也是 SLS、Prometheus、ClickHouse 等主流可观测系统的标准做法。