### PR TITLE
fix: 删除按request数重建wasm vm的配置

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ func init() {
 		wrapper.ProcessRequestBody(onHttpRequestBody),
 		wrapper.ProcessResponseHeaders(onHttpResponseHeaders),
 		wrapper.ProcessResponseBody(onHttpResponseBody),
-		wrapper.WithRebuildAfterRequests[PluginConfig](1000),
 		wrapper.WithRebuildMaxMemBytes[PluginConfig](200*1024*1024),
 	)
 }


### PR DESCRIPTION
requests速率太高导致wasm vm不断重建，会直接让etcd使用率飙高且其他wasm plugins受影响